### PR TITLE
More helpful error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.1.0
+-----
+
+Enable Rubocop's `DisplayStyleGuide` and `ExtraDetails` options so more helpful error messages are displayed for offences
 
 2.0.0
 -----

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "gc_ruboconfig"
-  spec.version       = "2.0.0"
+  spec.version       = "2.1.0"
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w(GoCardless)
   spec.homepage      = "https://github.com/gocardless/ruboconfig"

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,5 +1,7 @@
 AllCops:
   DisplayCopNames: true
+  DisplayStyleGuide: true
+  ExtraDetails: true
   Exclude:
     - .*/**/*
     - vendor/**/*


### PR DESCRIPTION
* Setting `DisplayStyleGuide` will include the URL of any appropriate style guide entry, like [this](https://github.com/bbatsov/rubocop/blob/f6d46a281188b2e46af588b7efa215a3688918dc/spec/rubocop/cli_spec.rb#L936) - that's quite nice, as you can go and see why the rule is as such, and sometimes how to fix it/.
* Setting `ExtraDetails` means that cops can include extra helpful details on their offences like [this](https://github.com/bbatsov/rubocop/blob/23876e2e4ed849f2adc976ebe711c4c6a552c8f8/lib/rubocop/cop/message_annotator.rb#L58) - but I can't see any that do that at the moment!