### PR TITLE
Include rubocop-rspec with Ruboconfig and configure it like existing projects

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -9,4 +9,5 @@ Gem::Specification.new do |spec|
 
   spec.files         = "rubocop.yml"
   spec.add_development_dependency "rubocop", "~> 0.52.1"
+  spec.add_development_dependency "rubocop-rspec", "~> 1.21.0"
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-rspec
+
 AllCops:
   DisplayCopNames: true
   DisplayStyleGuide: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -107,3 +107,12 @@ Style/YodaCondition:
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: space
+
+RSpec/NotToNot:
+  EnforcedStyle: to_not
+
+RSpec/ContextWording:
+  Enabled: false
+
+RSpec/AnyInstance:
+  Enabled: false


### PR DESCRIPTION
We've been using the [`rubocop-rspec`][] gem with success to standardise on good style in our specs.

Let's start using it in Ruboconfig too, by adding it to the gemspec as a gem dependency, and requiring it in `rubocop.yml` so its cops are available.

Let's also copy over the [`rubocop-rspec`][] related rules from other projects' `.rubocop.yml`s to use them in `gc-ruboconfig`.

We may also want to take some of the rules from `.rubocop_todo.yml`s, but that should be discussed first.

[`rubocop-rspec`]: https://github.com/backus/rubocop-rspec