### PR TITLE
Bind to `rubocop` and `rubocop-rspec` as production dependencies

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = "rubocop.yml"
-  spec.add_development_dependency "rubocop", "~> 0.52.1"
-  spec.add_development_dependency "rubocop-rspec", "~> 1.21.0"
+  spec.add_dependency "rubocop", "~> 0.52.1"
+  spec.add_dependency "rubocop-rspec", "~> 1.21.0"
 end

--- a/validate_config.rb
+++ b/validate_config.rb
@@ -1,6 +1,8 @@
 require 'rubygems'
 
-Bundler.require(:development)
+Bundler.require(:default)
+
+require 'rubocop'
 
 $stderr = StringIO.new
 


### PR DESCRIPTION
At the moment, `rubocop` and `rubocop-rspec` are defined in the gemspec as development dependencies, so they'll only get installed by Bundler when using the gem in a development capacity.

This isn't working too well for us since adding `rubocop-rspec`, as our shared Rubocop configuration file tries to load that gem and it hasn't been installed, so running Rubocop fails.

This switches to specifying `rubocop` and `rubocop-rspec` (and their versions) as general, rather than development, dependencies.

I think this makes sense, as in reality the configuration is specific to particular versions, since the cops that are available, their behaviour and how they are configurable is all dependent on the current version of these gems.

Specifying the gem versions you have to use here will make sure the shared configuration behaves as expected across the board. You'll then, in products using `gc_ruboconfig`, just need to specify a dependency on `gc_ruboconfig` and let it do the rest.