### PR TITLE
Run CI using CircleCI 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,30 @@
+version: 2
+jobs:
+  build:
+    parallelism: 3
+    working_directory: ~/gc_ruboconfig
+    docker:
+      - image: circleci/ruby:2.5
+        environment:
+          BUNDLE_JOBS: 3
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - gc-ruboconfig-{{ checksum "gc_ruboconfig.gemspec" }}-{{ checksum "Gemfile" }}
+            - gc-ruboconfig-
+
+      - run:
+          name: Bundle Install
+          command: bundle check || bundle install
+
+      - save_cache:
+          key: gc-ruboconfig-{{ checksum "gc_ruboconfig.gemspec" }}-{{ checksum "Gemfile" }}
+          paths:
+            - vendor/bundle
+
+      - type: shell
+        command: bundle exec ruby validate_config.rb

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-test:
-  pre:
-    - bundle exec ruby validate_config.rb


### PR DESCRIPTION
This switches from CircleCI 1.0 to CircleCI 2.0, slightly adapting the basic [example][] on CircleCI's website.

This makes this project more consistent with other GoCardless codebases, and lets you simply run tests locally with `circleci build` and CircleCI's [CLI][].

[example]: https://circleci.com/docs/2.0/language-ruby/
[CLI]: https://circleci.com/docs/2.0/local-jobs/  