### PR TITLE
Configure RSpec/MessageSpies to enforce `expect(foo).to receive(:bar)`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -116,3 +116,6 @@ RSpec/ContextWording:
 
 RSpec/AnyInstance:
   Enabled: false
+
+RSpec/MessageSpies:
+  EnforcedStyle: receive


### PR DESCRIPTION
The [RSpec/MessageSpies][MessageSpies] cop enforces a particular style for setting message expectations.

`rubocop-rspec`'s default is to use spies. However, as a convention, we've always used mocks and I'm quite happy for it to stay this way. (Although using spies does have some benefits - especially that it only works on test doubles so you can't set expectations all over the place, for example on classes from gems).

This switches to expecting:

```ruby
# good
expect(foo).to receive(:bar)

# bad
expect(foo).to have_received(:bar)
```
  
[MessageSpies]: http://www.rubydoc.info/gems/rubocop-rspec/1.10.0/RuboCop/Cop/RSpec/MessageSpies