### PR TITLE
Allow more "nested groups" in RSpec

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -119,3 +119,6 @@ RSpec/AnyInstance:
 
 RSpec/MessageSpies:
   EnforcedStyle: receive
+
+RSpec/NestedGroups:
+  Max: 4


### PR DESCRIPTION
It's nice to avoid nesting our specs too deep, but rubocop-rspec's default maximum of 3 feels too low, given that you'll always have a root `describe` for the class followed usually by a `describe` for the method you're testing.

If you've got a maximum of 3, that means you can't have any further nesting after that and must just have examples, which is very restrictive and doesn't feel conducive to sensible tests.

In some of our projects we allow as many as 8, which feels too many, but I'd suggest one more would make sense to allow a bit more logical grouping, for example this kind of common "categorisation" case:

```ruby
RSpec.describe Widget do
  subject(:widget) { FactoryBot.build(:widget) }

  describe "#colour" do
    subject { widget.colour }

    context "with a red widget" do
      let(:widget) { FactoryBot.build(:widget, :red) }

      it { is_expected.to eq(:red) }
    end
  end
end
```