### PR TITLE
v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.3.3
+-----
+
+* Bump rubocop to v0.53.0, renaming a few cops in the configuration to match their new names
+* Enable the `Lint/UnneededCopEnableDirective` cop, to work alongside the already-enabled `Lint/UnneededCopDisableDirective` cop
+* Fix `validate_config.rb` so it correctly outputs any problems with the `rubocop.yml` file, rather than just exiting silently with an appropriate code
+
 2.3.2
 -----
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "gc_ruboconfig"
-  spec.version       = "2.3.2"
+  spec.version       = "2.3.3"
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w(GoCardless)
   spec.homepage      = "https://github.com/gocardless/ruboconfig"


### PR DESCRIPTION
* Bump rubocop to v0.53.0, renaming a few cops in the configuration to match their new names
* Enable the `Lint/UnneededCopEnableDirective` cop, to work alongside the already-enabled `Lint/UnneededCopDisableDirective` cop
* Fix `validate_config.rb` so it correctly outputs any problems with the `rubocop.yml` file, rather than just exiting silently with an appropriate code