### PR TITLE
Use implicit StandardError rescue

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -133,3 +133,6 @@ RSpec/Pending:
 # https://github.com/rubocop-hq/rubocop/issues/5953
 Style/AccessModifierDeclarations:
   Enabled: false
+
+Style/RescueStandardError:
+  EnforcedStyle: implicit


### PR DESCRIPTION
### Explicit

```ruby
rescue StandardError => e
  ...
```

### Implicit

```ruby
rescue => e
  ..
```