### PR TITLE
Disable Style/ModuleFunction

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -133,3 +133,8 @@ RSpec/Pending:
 # https://github.com/rubocop-hq/rubocop/issues/5953
 Style/AccessModifierDeclarations:
   Enabled: false
+
+# Re-enable this when the following is resolved:
+# https://github.com/rubocop-hq/ruby-style-guide/issues/556
+Style/ModuleFunction:
+  Enabled: false


### PR DESCRIPTION
This cop implies that `extend self` and `module_function` behave the same way, but they actually handle reflections and private method visibility in slightly different ways. See here for more info:
https://idiosyncratic-ruby.com/8-self-improvement.html

Issue against Rubocop:
https://github.com/rubocop-hq/ruby-style-guide/issues/556