### PR TITLE
Include rubocop-rails gem

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.4.0'
+  spec.version       = '2.5.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -9,5 +9,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = 'rubocop.yml'
   spec.add_dependency 'rubocop', '>= 0.70'
+  spec.add_dependency 'rubocop-rails', '>= 2.0.1'
   spec.add_dependency 'rubocop-rspec', '>= 1.33.0'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,4 +1,6 @@
-require: rubocop-rspec
+require:
+  - rubocop-rails
+  - rubocop-rspec
 
 AllCops:
   DisplayCopNames: true


### PR DESCRIPTION
Rails cops will be [deprecated](https://github.com/rubocop-hq/rubocop/pull/7095) from base Rubocop in v0.72 so the separate gem must now be included.