### PR TITLE
Bump rubocop to 0.75 and rubocop-rspec to 1.36.0

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -8,6 +8,6 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.70'
-  spec.add_dependency 'rubocop-rspec', '>= 1.33.0'
+  spec.add_dependency 'rubocop', '>= 0.75'
+  spec.add_dependency 'rubocop-rspec', '>= 1.36.0'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -48,13 +48,13 @@ Layout/DotPosition:
   EnforcedStyle: trailing
 
 Style/Encoding:
-  Enabled: never
+  Enabled: false
 
 Style/FormatString:
   EnforcedStyle: sprintf
 
 Style/FrozenStringLiteralComment:
-  Enabled: always
+  Enabled: true
 
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma


### PR DESCRIPTION
The new Rubocop release verifies that the Enabled field is a boolean.