### PR TITLE
Cache rubocop runs

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,7 @@
 require: rubocop-rspec
 
 AllCops:
+  UseCache: true
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: true


### PR DESCRIPTION
Docs https://github.com/rubocop-hq/rubocop/blob/master/manual/caching.md

When running `bundle exec rubocop` we can cache the previous runs so that we can skip files that haven't changed:

```bash
# Without cache
➜  foo_repo git:(master) ✗ time be rubocop -C false
bundle exec rubocop -C false  29.78s user 0.79s system 91% cpu 33.379 total

# With cache:
➜  foo_repo git:(master) ✗ time be rubocop -C true
bundle exec rubocop  1.47s user 0.59s system 89% cpu 2.296 total
```