### PR TITLE
Disable RSpec/ImplicitBlockExpectation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.6.1
+-----
+
+* Disable RSpec/ImplicitBlockExpectation [#58]
+
 2.6.0
 -----
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.6.0'
+  spec.version       = '2.6.1'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -129,6 +129,9 @@ RSpec/MessageSpies:
 RSpec/Pending:
   Enabled: true
 
+RSpec/ImplicitBlockExpectation:
+  Enabled: false
+
 # Re-enable this when the following is resolved:
 # https://github.com/rubocop-hq/rubocop/issues/5953
 Style/AccessModifierDeclarations:


### PR DESCRIPTION
We turned this of in one of our main repos and have decided as an organisation that this cop isn't useful for us.