### PR TITLE
Add Rubocop Performance extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.7.0
+-----
+
+* Add rubocop-performance lib [#59]
+
 2.6.1
 -----
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,4 +10,5 @@ Gem::Specification.new do |spec|
   spec.files         = 'rubocop.yml'
   spec.add_dependency 'rubocop', '>= 0.76'
   spec.add_dependency 'rubocop-rspec', '>= 1.33.0'
+  spec.add_dependency 'rubocop-performance', '~> 1.5'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.6.1'
+  spec.version       = '2.7.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'


### PR DESCRIPTION
This [library](https://github.com/rubocop-hq/rubocop-performance) adds extra checks for common performance pitfalls, e.g. searching a hash ineffeciently.

We already utilise this in other applications, this just brings it into our libraries by default.