### PR TITLE
Bump Rubocop to v0.78.0

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.77'
+  spec.add_dependency 'rubocop', '>= 0.78'
   spec.add_dependency 'rubocop-rspec', '>= 1.33.0'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -21,7 +21,7 @@ Lint/RedundantCopDisableDirective:
 Metrics/ClassLength:
   Enabled: false
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 90
 
 Metrics/BlockLength:


### PR DESCRIPTION
This handles the breaking change in https://github.com/rubocop-hq/rubocop/pull/7542.