### PR TITLE
Enable two new cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.11.0
+------
+
+* Bump rubocop version to v0.82 and enable two new cops (`Layout/SpaceAroundMethodCallOperator`
+  and `Style/ExponentialNotation`)
+
 2.10.0
 ------
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.80'
+  spec.add_dependency 'rubocop', '>= 0.82'
   spec.add_dependency 'rubocop-rspec', '>= 1.38.1'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.10.0'
+  spec.version       = '2.11.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -116,6 +116,9 @@ Layout/SpaceBeforeBlockBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: space
 
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
 RSpec/NotToNot:
   EnforcedStyle: to_not
 
@@ -151,4 +154,7 @@ Style/HashTransformKeys:
   Enabled: true
 
 Style/HashTransformValues:
+  Enabled: true
+
+Style/ExponentialNotation:
   Enabled: true


### PR DESCRIPTION
- [`Layout/SpaceAroundMethodCallOperator`](https://docs.rubocop.org/en/latest/cops_layout/#layoutspacearoundmethodcalloperator)
- [`Style/ExponentialNotation`](https://rubocop.readthedocs.io/en/latest/cops_style/#styleexponentialnotation) (with a 'scientific' notation as default)

Bit unsure about the last one but I suspect we don't use it that much so hopefully it doesn't matter