### PR TITLE
Enable new cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.12.0
+------
+* Enable two cops introduced by rubocop v0.81: `Lint/RaiseException` and `Lint/StructNewOverride`
+
 2.11.0
 ------
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.11.0'
+  spec.version       = '2.12.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -18,6 +18,12 @@ Lint/RedundantCopEnableDirective:
 Lint/RedundantCopDisableDirective:
   Severity: error
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/ClassLength:
   Enabled: false
 


### PR DESCRIPTION
These were introduced by 0.81, enabling them by default as they seem sensible.