### PR TITLE
Enable support for cops introduced by 0.85

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changelog
 2.15.0
 ------
 * Support new cops introduced by rubocop v0.85: `Lint/MixedRegexpCaptureTypes`, `Style/RedundantRegexpEscape`
-  and `Style/RedundantRegexpCharacterClass` (disabled by default)
+  and `Style/RedundantRegexpCharacterClass`
 
 2.14.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ Changelog
 
 2.15.0
 ------
-* Support new cop introduced by rubocop v0.87: `Style/AccessorGrouping`, `Style/BisectedAttrAccessor`
-  and `Style/RedundantAssignment`
+* Support new cop introduced by rubocop v0.87: `Style/AccessorGrouping` (disabled by default),
+  `Style/BisectedAttrAccessor` and `Style/RedundantAssignment`
 * Support new cop introduced by rubocop v0.86: `Style/RedundantFetchBlock`
 * Support new cops introduced by rubocop v0.85: `Lint/MixedRegexpCaptureTypes`, `Style/RedundantRegexpEscape`
   and `Style/RedundantRegexpCharacterClass`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 2.15.0
 ------
+* Support new cop introduced by rubocop v0.87: `Style/AccessorGrouping`, `Style/BisectedAttrAccessor`
+  and `Style/RedundantAssignment`
 * Support new cop introduced by rubocop v0.86: `Style/RedundantFetchBlock`
 * Support new cops introduced by rubocop v0.85: `Lint/MixedRegexpCaptureTypes`, `Style/RedundantRegexpEscape`
   and `Style/RedundantRegexpCharacterClass`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 2.15.0
 ------
+* Support new cop introduced by rubocop v0.86: `Style/RedundantFetchBlock`
 * Support new cops introduced by rubocop v0.85: `Lint/MixedRegexpCaptureTypes`, `Style/RedundantRegexpEscape`
   and `Style/RedundantRegexpCharacterClass`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.15.0
+------
+* Support new cops introduced by rubocop v0.85: `Lint/MixedRegexpCaptureTypes`, `Style/RedundantRegexpEscape`
+  and `Style/RedundantRegexpCharacterClass` (disabled by default)
+
 2.14.0
 ------
 * Enable a new cop introduced by rubocop v0.84: `Lint/DeprecatedOpenSSLConstant`

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.85'
+  spec.add_dependency 'rubocop', '>= 0.87'
   spec.add_dependency 'rubocop-rspec', '>= 1.38.1'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.14.0'
+  spec.version       = '2.15.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.84'
+  spec.add_dependency 'rubocop', '>= 0.85'
   spec.add_dependency 'rubocop-rspec', '>= 1.38.1'
   spec.add_dependency 'rubocop-performance', '~> 1.5'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -24,6 +24,9 @@ Lint/RaiseException:
 Lint/StructNewOverride:
   Enabled: true
 
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
 Metrics/ClassLength:
   Enabled: false
 
@@ -169,6 +172,14 @@ Style/ExponentialNotation:
   Enabled: true
 
 Style/SlicingWithRange:
+  Enabled: true
+
+# Re-enable this when the following is resolved:
+# https://github.com/rubocop-hq/rubocop/issues/8098
+Style/RedundantRegexpCharacterClass:
+  Enabled: false
+
+Style/RedundantRegexpEscape:
   Enabled: true
 
 Lint/DeprecatedOpenSSLConstant:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -184,7 +184,7 @@ Style/RedundantFetchBlock:
   Enabled: true
 
 Style/AccessorGrouping:
-  Enabled: true
+  Enabled: false
 
 Style/BisectedAttrAccessor:
   Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -183,5 +183,14 @@ Style/RedundantRegexpEscape:
 Style/RedundantFetchBlock:
   Enabled: true
 
+Style/AccessorGrouping:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: true
+
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -174,10 +174,8 @@ Style/ExponentialNotation:
 Style/SlicingWithRange:
   Enabled: true
 
-# Re-enable this when the following is resolved:
-# https://github.com/rubocop-hq/rubocop/issues/8098
 Style/RedundantRegexpCharacterClass:
-  Enabled: false
+  Enabled: true
 
 Style/RedundantRegexpEscape:
   Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -180,5 +180,8 @@ Style/RedundantRegexpCharacterClass:
 Style/RedundantRegexpEscape:
   Enabled: true
 
+Style/RedundantFetchBlock:
+  Enabled: true
+
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true


### PR DESCRIPTION
Namely:

- `Lint/MixedRegexpCaptureTypes`
- `Style/RedundantRegexpCharacterClass`
- `Style/RedundantRegexpEscape`
- `Style/AccessorGrouping`
- `Style/BisectedAttrAccessor`
- `Style/RedundantAssignment`
- `Style/RedundantFetchBlock`