### PR TITLE
Enable new cops from rubocop-performance v1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+2.16.0
+------
+
+* Enable new cops introduced by rubocop-performance v1.7:
+  - `Performance/AncestorsInclude`
+  - `Performance/BigDecimalWithNumericArgument`
+  - `Performance/RedundantSortBlock`
+  - `Performance/ReverseFirst`
+  - `Performance/SortReverse`
+  - `Performance/Squeeze`
+  - `Performance/StringInclude`
+
 2.15.0
 ------
 * Support new cop introduced by rubocop v0.87: `Style/AccessorGrouping` (disabled by default),

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.15.0'
+  spec.version       = '2.16.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -12,5 +12,5 @@ Gem::Specification.new do |spec|
   spec.files         = 'rubocop.yml'
   spec.add_dependency 'rubocop', '>= 0.87'
   spec.add_dependency 'rubocop-rspec', '>= 1.38.1'
-  spec.add_dependency 'rubocop-performance', '~> 1.5'
+  spec.add_dependency 'rubocop-performance', '~> 1.7'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -194,3 +194,24 @@ Style/RedundantAssignment:
 
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
+
+Performance/AncestorsInclude:
+  Enabled: true
+
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+
+Performance/RedundantSortBlock:
+  Enabled: true
+
+Performance/ReverseFirst:
+  Enabled: true
+
+Performance/SortReverse:
+  Enabled: true
+
+Performance/Squeeze:
+  Enabled: true
+
+Performance/StringInclude:
+  Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -204,6 +204,11 @@ Performance/BigDecimalWithNumericArgument:
 Performance/RedundantSortBlock:
   Enabled: true
 
+# Disabled as it removes some idiomatic code, and does some byte/char moving around
+# encoding which we're not confident with.
+Performance/RedundantStringChars:
+  Enabled: false
+
 Performance/ReverseFirst:
   Enabled: true
 


### PR DESCRIPTION
Enables the following cops:

- `Performance/AncestorsInclude`
- `Performance/BigDecimalWithNumericArgument`
- `Performance/RedundantSortBlock`
- `Performance/ReverseFirst`
- `Performance/SortReverse`
- `Performance/Squeeze`
- `Performance/StringInclude`

`Performance/RedundantStringChars` is disabled as it removes some idiomatic code, and does some byte/char moving around encoding which we're not confident with.