### PR TITLE
Enable new cops for Rubocop v0.88

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2.17.0
+------
+
+* Enable new cops introduced by rubocop v0.88:
+  - `Lint/DuplicateElsifCondition`
+  - `Style/ArrayCoercion`
+  - `Style/CaseLikeIf`
+  - `Style/HashLikeCase`
+  - `Style/RedundantFileExtensionInRequire`
+
 2.16.0
 ------
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.16.0'
+  spec.version       = '2.17.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.87'
+  spec.add_dependency 'rubocop', '>= 0.88'
   spec.add_dependency 'rubocop-rspec', '>= 1.38.1'
   spec.add_dependency 'rubocop-performance', '~> 1.7'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -220,3 +220,25 @@ Performance/Squeeze:
 
 Performance/StringInclude:
   Enabled: true
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+  # Disable auto-correct since there's usually a cleaner fix than the one it suggests.
+  AutoCorrect: false
+
+Style/CaseLikeIf:
+  Enabled: true
+
+# Disabled as the two styles that can be chosen are both idiomatic in some places, and
+# not in others.
+Style/HashAsLastArrayItem:
+  Enabled: false
+
+Style/HashLikeCase:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: true


### PR DESCRIPTION
- Lint/DuplicateElsifCondition: this prevents some fairly obvious bugs.
- Style/ArrayCoercion: this is good style.  We have a small number of violations, but most are cases where the autocorrect isn't helpful (e.g. replacing `*[*1]` with `Array(1)`, rather than just `[1]`).  Fixing manually feels like the way to go, and is pretty easy.
- Style/CaseLikeIf: nice cleanup with an autocorrect.
- Style/HashAsLastArrayItem: this offers a choice between two different styles, but neither one looks right in all cases.  Have disabled.
- Style/HashLikeCase: no autocorrect, but only a couple of violations that are easy to fix.
- Style/RedundantFileExtensionInRequire: nice style fix with autocorrect