### PR TITLE
Set the max number of memoized helpers to 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.18.0
+------
+* Set a larger default for `RSpec/MultipleMemoizedHelpers`
+
 2.17.0
 ------
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = 'rubocop.yml'
   spec.add_dependency 'rubocop', '>= 0.88'
-  spec.add_dependency 'rubocop-rspec', '>= 1.38.1'
+  spec.add_dependency 'rubocop-rspec', '>= 1.43.1'
   spec.add_dependency 'rubocop-performance', '~> 1.7'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -149,6 +149,9 @@ RSpec/Pending:
 RSpec/ImplicitBlockExpectation:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 30
+
 # Re-enable this when the following is resolved:
 # https://github.com/rubocop-hq/rubocop/issues/5953
 Style/AccessModifierDeclarations:


### PR DESCRIPTION
Brought to you by the recent rubocop-rspec update...

It doesn't take much even on small projects to get more memoized helpers
than the default (5!). In the large projects I've checked this we get
close to 30 but hardly ever over that so this seems a sensible default.