### PR TITLE
Update rubocop and rubocop-rspec cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Changelog
 2.18.0
 ------
 * Set a larger default for `RSpec/MultipleMemoizedHelpers`
+* Enable new cops introduced by rubocop v0.89:
+ - `Lint/BinaryOperatorWithIdenticalOperands`
+ - `Lint/DuplicateRescueException`
+ - `Lint/EmptyConditionalBody`
+ - `Lint/FloatComparison`
+ - `Lint/MissingSuper`
+ - `Lint/OutOfRangeRegexpRef`
+ - `Lint/SelfAssignment`
+ - `Lint/TopLevelReturnWithArgument`
+ - `Lint/UnreachableLoop`
+ - `Style/ExplicitBlockArgument`
+ - `Style/GlobalStdStream`
+ - `Style/SingleArgumentDig`
+ - `Style/OptionalBooleanParameter`
+ - `Style/StringConcatenation`
 
 2.17.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.18.0
+------
+* Set a larger default for `RSpec/MultipleMemoizedHelpers`
+
 2.17.0
 ------
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -11,6 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.files         = 'rubocop.yml'
   spec.add_dependency 'rubocop', '>= 0.88'
-  spec.add_dependency 'rubocop-rspec', '>= 1.38.1'
+  spec.add_dependency 'rubocop-rspec', '>= 1.43.1'
   spec.add_dependency 'rubocop-performance', '~> 1.7'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.17.0'
+  spec.version       = '2.18.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.88'
+  spec.add_dependency 'rubocop', '>= 0.89'
   spec.add_dependency 'rubocop-rspec', '>= 1.43.1'
   spec.add_dependency 'rubocop-performance', '~> 1.7'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -149,6 +149,9 @@ RSpec/Pending:
 RSpec/ImplicitBlockExpectation:
   Enabled: false
 
+RSpec/MultipleMemoizedHelpers:
+  Max: 30
+
 # Re-enable this when the following is resolved:
 # https://github.com/rubocop-hq/rubocop/issues/5953
 Style/AccessModifierDeclarations:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -48,6 +48,9 @@ Metrics/ModuleLength:
 Metrics/ParameterLists:
   CountKeywordArgs: false
 
+Metrics/PerceivedComplexity:
+  Max: 11
+
 Style/AsciiComments:
   Enabled: false
 
@@ -245,3 +248,4 @@ Style/HashLikeCase:
 
 Style/RedundantFileExtensionInRequire:
   Enabled: true
+

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -249,3 +249,44 @@ Style/HashLikeCase:
 Style/RedundantFileExtensionInRequire:
   Enabled: true
 
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
+
+Style/ExplicitBlockArgument:
+  Enabled: true
+
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/SingleArgumentDig:
+  Enabled: true
+
+Style/OptionalBooleanParameter:
+  Enabled: false
+
+Style/StringConcatenation:
+  Enabled: false


### PR DESCRIPTION
- Increases the threshold for `Metrics/PerceivedComplexity`: something has changed and now it takes very little for this to be raised.
- Set a larger default for `RSpec/MultipleMemoizedHelpers`: this is a new one, it only takes 5 `let`/`let!` to trigger it... I've raised this to 30 which seems to make sense for most projects.
- Enable/disable a bunch of other cops from rubocop 0.89:
  - `Lint/BinaryOperatorWithIdenticalOperands`
  - `Lint/DuplicateRescueException`
  - `Lint/EmptyConditionalBody`
  - `Lint/FloatComparison`
  - `Lint/MissingSuper`
  - `Lint/OutOfRangeRegexpRef`
  - `Lint/SelfAssignment`
  - `Lint/TopLevelReturnWithArgument`
  - `Lint/UnreachableLoop`
  - `Style/ExplicitBlockArgument`
  - `Style/GlobalStdStream`
  - `Style/SingleArgumentDig`
  - `Style/OptionalBooleanParameter` (disabled by default)
  - `Style/StringConcatenation` (disabled by default)