### PR TITLE
Enable support for new cops introduced by rubocop v0.90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+2.19.0
+------
+* Enable support for new cops introduced by rubocop v0.90:
+ - `Lint/DuplicateRequire`
+ - `Lint/EmptyFile`
+ - `Lint/TrailingCommaInAttributeDeclaration`
+ - `Lint/UselessMethodDefinition`
+ - `Style/CombinableLoops`
+ - `Style/KeywordParametersOrder`
+ - `Style/RedundantSelfAssignment`
+ - `Style/SoleNestedConditional` (disabled by default)
+
 2.18.0
 ------
 * Set a larger default for `RSpec/MultipleMemoizedHelpers`

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.18.0'
+  spec.version       = '2.19.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.89'
+  spec.add_dependency 'rubocop', '>= 0.90'
   spec.add_dependency 'rubocop-rspec', '>= 1.43.1'
   spec.add_dependency 'rubocop-performance', '~> 1.7'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -276,6 +276,18 @@ Lint/TopLevelReturnWithArgument:
 Lint/UnreachableLoop:
   Enabled: true
 
+Lint/DuplicateRequire:
+  Enabled: true
+
+Lint/EmptyFile:
+  Enabled: true
+
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+
+Lint/UselessMethodDefinition:
+  Enabled: true
+
 Style/ExplicitBlockArgument:
   Enabled: true
 
@@ -289,4 +301,16 @@ Style/OptionalBooleanParameter:
   Enabled: false
 
 Style/StringConcatenation:
+  Enabled: false
+
+Style/CombinableLoops:
+  Enabled: true
+
+Style/KeywordParametersOrder:
+  Enabled: true
+
+Style/RedundantSelfAssignment:
+  Enabled: true
+
+Style/SoleNestedConditional:
   Enabled: false


### PR DESCRIPTION
 - `Lint/DuplicateRequire`
 - `Lint/EmptyFile`
 - `Lint/TrailingCommaInAttributeDeclaration`
 - `Lint/UselessMethodDefinition`
 - `Style/CombinableLoops`
 - `Style/KeywordParametersOrder`
 - `Style/RedundantSelfAssignment`
 - `Style/SoleNestedConditional` (disabled by default)
