### PR TITLE
Add support for rubocop 0.93, rubocop-rspec 1.44 and rubocop-performance 1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+2.20.0
+------
+* Enable support for new cops introduced by rubocop v0.91, v0.92 and v0.93,
+  rubocop-rspec 1.44 and rubocop-performance 1.8:
+ - `RSpec/StubbedMock` (disabled by default)
+ - `Performance/Sum`
+ - `Lint/ConstantDefinitionInBlock`
+ - `Lint/HashCompareByIdentity`
+ - `Lint/IdentityComparison`
+ - `Lint/RedundantSafeNavigation`
+ - `Lint/UselessTimes`
+ - `Style/ClassEqualityComparison`
+ - `Layout/BeginEndAlignment`
+
 2.19.0
 ------
 * Enable support for new cops introduced by rubocop v0.90:

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.19.0'
+  spec.version       = '2.20.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.90'
-  spec.add_dependency 'rubocop-rspec', '>= 1.43.1'
-  spec.add_dependency 'rubocop-performance', '~> 1.7'
+  spec.add_dependency 'rubocop', '>= 0.93'
+  spec.add_dependency 'rubocop-rspec', '>= 1.44.1'
+  spec.add_dependency 'rubocop-performance', '~> 1.8.1'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -156,7 +156,7 @@ RSpec/MultipleMemoizedHelpers:
   Max: 30
 
 RSpec/StubbedMock:
-  Enabled: true
+  Enabled: false
 
 # Re-enable this when the following is resolved:
 # https://github.com/rubocop-hq/rubocop/issues/5953

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -155,6 +155,9 @@ RSpec/ImplicitBlockExpectation:
 RSpec/MultipleMemoizedHelpers:
   Max: 30
 
+RSpec/StubbedMock:
+  Enabled: true
+
 # Re-enable this when the following is resolved:
 # https://github.com/rubocop-hq/rubocop/issues/5953
 Style/AccessModifierDeclarations:
@@ -208,6 +211,9 @@ Performance/BigDecimalWithNumericArgument:
   Enabled: true
 
 Performance/RedundantSortBlock:
+  Enabled: true
+
+Performance/Sum:
   Enabled: true
 
 # Disabled as it removes some idiomatic code, and does some byte/char moving around
@@ -288,6 +294,21 @@ Lint/TrailingCommaInAttributeDeclaration:
 Lint/UselessMethodDefinition:
   Enabled: true
 
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+
+Lint/HashCompareByIdentity:
+  Enabled: true
+
+Lint/IdentityComparison:
+  Enabled: true
+
+Lint/RedundantSafeNavigation:
+  Enabled: true
+
+Lint/UselessTimes:
+  Enabled: true
+
 Style/ExplicitBlockArgument:
   Enabled: true
 
@@ -314,3 +335,9 @@ Style/RedundantSelfAssignment:
 
 Style/SoleNestedConditional:
   Enabled: false
+
+Style/ClassEqualityComparison:
+  Enabled: true
+
+Layout/BeginEndAlignment:
+  Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -304,7 +304,7 @@ Style/StringConcatenation:
   Enabled: false
 
 Style/CombinableLoops:
-  Enabled: true
+  Enabled: false
 
 Style/KeywordParametersOrder:
   Enabled: true


### PR DESCRIPTION
Enable support for new cops introduced by rubocop v0.91, v0.92 and v0.93, rubocop-rspec 1.44 and rubocop-performance 1.8:

 - `RSpec/StubbedMock` (disabled by default)
 - `Performance/Sum`
 - `Lint/ConstantDefinitionInBlock`
 - `Lint/HashCompareByIdentity`
 - `Lint/IdentityComparison`
 - `Lint/RedundantSafeNavigation`
 - `Lint/UselessTimes`
 - `Style/ClassEqualityComparison`
 - `Layout/BeginEndAlignment`

Bit on the fence with `Lint/ConstantDefinitionInBlock` as basically makes sense but breaks in rspec (e.g. in `before` blocks). Probably ok with enabling this by default, but then exclude it for anything under `spec`? (have tried this branch on [ps](https://app.circleci.com/pipelines/github/gocardless/payments-service/49081/workflows/ee963f7a-f99e-4d38-97e3-cf17b2635116/jobs/1058195) internally, the failures seem... ok? once you remove `ConstantDefinitionInBlock`)

Also ideally we'd point at rubocop 1.x but rubocop-rspec is pinned to 0.x for now...