### PR TITLE
Disable Lint/ConstantDefinitionInBlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.21.0
+------
+* Disabled `Lint/ConstantDefinitionInBlock` by default
+
 2.20.0
 ------
 * Enable support for new cops introduced by rubocop v0.91, v0.92 and v0.93,

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -295,7 +295,7 @@ Lint/UselessMethodDefinition:
   Enabled: true
 
 Lint/ConstantDefinitionInBlock:
-  Enabled: true
+  Enabled: false
 
 Lint/HashCompareByIdentity:
   Enabled: true


### PR DESCRIPTION
Seems like this is causing enough false positives that it's worth
keeping it disabled as the gains are minimal.