### PR TITLE
Support Rubocop 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 2.21.0
 ------
 * Disabled `Lint/ConstantDefinitionInBlock` by default
+* Require rubocop 1.0
 
 2.20.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.21.0
+------
+* Disabled `Lint/ConstantDefinitionInBlock` by default
+
 2.20.0
 ------
 * Enable support for new cops introduced by rubocop v0.91, v0.92 and v0.93,

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.20.0'
+  spec.version       = '2.21.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 0.93'
-  spec.add_dependency 'rubocop-rspec', '>= 1.44.1'
+  spec.add_dependency 'rubocop', '>= 1.0'
+  spec.add_dependency 'rubocop-rspec', '>= 2.0.0'
   spec.add_dependency 'rubocop-performance', '~> 1.8.1'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -295,7 +295,7 @@ Lint/UselessMethodDefinition:
   Enabled: true
 
 Lint/ConstantDefinitionInBlock:
-  Enabled: true
+  Enabled: false
 
 Lint/HashCompareByIdentity:
   Enabled: true


### PR DESCRIPTION
(also disables `Lint/ConstantDefinitionInBlock`)

Need to wait for a proper release of rubocop-rspec before we can merge/release...