### PR TITLE
Support new rubocop-* releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+2.22.0
+------
+* Enable support for new cops introduced by rubocop v1.1, v1.2 and v1.3:
+ - Lint/DuplicateBranch (disabled by default)
+ - Lint/EmptyBlock (disabled by default)
+ - Lint/NoReturnInBeginEndBlocks (disabled by default)
+ - Style/CommentAnnotation (disabled by default)
+ - Style/DocumentDynamicEvalDefinition (disabled by default)
+ - Style/NegatedIfElseCondition (disabled by default)
+ - Lint/DuplicateRegexpCharacterClassElement
+ - Lint/ToEnumArguments
+ - Lint/UnmodifiedReduceAccumulator
+ - Style/ArgumentsForwarding
+ - Style/CollectionCompact
+ - Style/NilLambda
+ - Style/SwapValues
+
 2.21.0
 ------
 * Disabled `Lint/ConstantDefinitionInBlock` by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Changelog
  - Style/CollectionCompact
  - Style/NilLambda
  - Style/SwapValues
+* Enable support for new cops introduced by rubocop-performance 1.9:
+ - Performance/ArraySemiInfiniteRangeSlice (disabled by default)
+ - Performance/BlockGivenWithExplicitBlock
+ - Performance/CollectionLiteralInLoop
+ - Performance/ConstantRegexp
+ - Performance/MethodObjectAsBlock
 
 2.21.0
 ------

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |spec|
   spec.files         = 'rubocop.yml'
   spec.add_dependency 'rubocop', '>= 1.3'
   spec.add_dependency 'rubocop-rspec', '>= 2.0.0'
-  spec.add_dependency 'rubocop-performance', '~> 1.8'
+  spec.add_dependency 'rubocop-performance', '~> 1.9'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 1.0'
+  spec.add_dependency 'rubocop', '>= 1.3'
   spec.add_dependency 'rubocop-rspec', '>= 2.0.0'
   spec.add_dependency 'rubocop-performance', '~> 1.8.1'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.21.0'
+  spec.version       = '2.22.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -12,5 +12,5 @@ Gem::Specification.new do |spec|
   spec.files         = 'rubocop.yml'
   spec.add_dependency 'rubocop', '>= 1.3'
   spec.add_dependency 'rubocop-rspec', '>= 2.0.0'
-  spec.add_dependency 'rubocop-performance', '~> 1.8.1'
+  spec.add_dependency 'rubocop-performance', '~> 1.8'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -309,6 +309,9 @@ Lint/RedundantSafeNavigation:
 Lint/UselessTimes:
   Enabled: true
 
+Lint/DuplicateBranch:
+  Enabled: false
+
 Style/ExplicitBlockArgument:
   Enabled: true
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -339,5 +339,8 @@ Style/SoleNestedConditional:
 Style/ClassEqualityComparison:
   Enabled: true
 
+Style/CommentAnnotation:
+  Enabled: false
+
 Layout/BeginEndAlignment:
   Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -233,6 +233,21 @@ Performance/Squeeze:
 Performance/StringInclude:
   Enabled: true
 
+Performance/ArraySemiInfiniteRangeSlice:
+  Enabled: false
+
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+
+Performance/ConstantRegexp:
+  Enabled: true
+
+Performance/MethodObjectAsBlock:
+  Enabled: true
+
 Lint/DuplicateElsifCondition:
   Enabled: true
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -318,6 +318,15 @@ Lint/EmptyBlock:
 Lint/NoReturnInBeginEndBlocks:
   Enabled: false
 
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+
+Lint/ToEnumArguments:
+  Enabled: true
+
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
+
 Style/ExplicitBlockArgument:
   Enabled: true
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -345,5 +345,8 @@ Style/ClassEqualityComparison:
 Style/CommentAnnotation:
   Enabled: false
 
+Style/DocumentDynamicEvalDefinition:
+  Enabled: false
+
 Layout/BeginEndAlignment:
   Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -366,5 +366,17 @@ Style/DocumentDynamicEvalDefinition:
 Style/NegatedIfElseCondition:
   Enabled: false
 
+Style/ArgumentsForwarding:
+  Enabled: true
+
+Style/CollectionCompact:
+  Enabled: true
+
+Style/NilLambda:
+  Enabled: true
+
+Style/SwapValues:
+  Enabled: true
+
 Layout/BeginEndAlignment:
   Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -312,6 +312,9 @@ Lint/UselessTimes:
 Lint/DuplicateBranch:
   Enabled: false
 
+Lint/EmptyBlock:
+  Enabled: false
+
 Style/ExplicitBlockArgument:
   Enabled: true
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -315,6 +315,9 @@ Lint/DuplicateBranch:
 Lint/EmptyBlock:
   Enabled: false
 
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: false
+
 Style/ExplicitBlockArgument:
   Enabled: true
 

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -363,5 +363,8 @@ Style/CommentAnnotation:
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
 
+Style/NegatedIfElseCondition:
+  Enabled: false
+
 Layout/BeginEndAlignment:
   Enabled: true


### PR DESCRIPTION
* Enable support for new cops introduced by rubocop v1.1, v1.2 and v1.3:
  - Lint/DuplicateBranch (disabled by default)
  - Lint/EmptyBlock (disabled by default)
  - Lint/NoReturnInBeginEndBlocks (disabled by default)
  - Style/CommentAnnotation (disabled by default)
  - Style/DocumentDynamicEvalDefinition (disabled by default)
  - Style/NegatedIfElseCondition (disabled by default)
  - Lint/DuplicateRegexpCharacterClassElement
  - Lint/ToEnumArguments
  - Lint/UnmodifiedReduceAccumulator
  - Style/ArgumentsForwarding
  - Style/CollectionCompact
  - Style/NilLambda
  - Style/SwapValues
* Enable support for new cops introduced by rubocop-performance 1.9:
  - Performance/ArraySemiInfiniteRangeSlice (disabled by default)
  - Performance/BlockGivenWithExplicitBlock
  - Performance/CollectionLiteralInLoop
  - Performance/ConstantRegexp
  - Performance/MethodObjectAsBlock

(see individual commits for why some of these have been disabled)