### PR TITLE
Disable Lint/EmptyClass for specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.23.0
+------
+* Disable Lint/EmptyClass for specs
+
 2.22.0
 ------
 * Enable support for new cops introduced by rubocop v1.1, v1.2 and v1.3:

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.22.0'
+  spec.version       = '2.23.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -330,6 +330,10 @@ Lint/DuplicateBranch:
 Lint/EmptyBlock:
   Enabled: false
 
+Lint/EmptyClass:
+  Exclude:
+    - "spec/**/*"
+
 Lint/NoReturnInBeginEndBlocks:
   Enabled: false
 


### PR DESCRIPTION
It is fairly common to define an empty (mock) class in specs, but
shouldn't be a thing in normal app code so disable it only for specs.