### PR TITLE
Enable new rubocop 1.6 cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Changelog
 2.24.0
 ------
 * Add missing Lint/EmptyClass `enabled` flag
+* Enabled new cops:
+ - Style/RedundantArgument
+ - Lint/UnexpectedBlockArity
 
 2.23.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+2.24.0
+------
+* Add missing Lint/EmptyClass `enabled` flag
+
 2.23.0
 ------
 * Disable Lint/EmptyClass for specs

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.23.0'
+  spec.version       = '2.24.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 1.3'
-  spec.add_dependency 'rubocop-rspec', '>= 2.0.0'
+  spec.add_dependency 'rubocop', '>= 1.6'
+  spec.add_dependency 'rubocop-rspec', '>= 2.1.0'
   spec.add_dependency 'rubocop-performance', '~> 1.9'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -347,6 +347,9 @@ Lint/ToEnumArguments:
 Lint/UnmodifiedReduceAccumulator:
   Enabled: true
 
+Lint/UnexpectedBlockArity:
+  Enabled: true
+
 Style/ExplicitBlockArgument:
   Enabled: true
 
@@ -396,6 +399,9 @@ Style/NilLambda:
   Enabled: true
 
 Style/SwapValues:
+  Enabled: true
+
+Style/RedundantArgument:
   Enabled: true
 
 Layout/BeginEndAlignment:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -331,6 +331,7 @@ Lint/EmptyBlock:
   Enabled: false
 
 Lint/EmptyClass:
+  Enabled: true
   Exclude:
     - "spec/**/*"
 


### PR DESCRIPTION
* Add missing Lint/EmptyClass `enabled` flag
* Enabled new cops:
  - Style/RedundantArgument
  - Lint/UnexpectedBlockArity

Tested this [against ps](https://app.circleci.com/pipelines/github/gocardless/payments-service/53699/workflows/46be55ca-0b91-4ae3-b5b1-c467d1b94568/jobs/1140823) internally, most of the changes are autocorrectable, seems like the major offender is calling `.split(" ")` where the argument can be omitted as [it's a whitespace by default](https://ruby-doc.org/core-2.7.2/String.html#method-i-split).