### PR TITLE
Enable new cops for rubocop 1.16 and rubocop-performance 1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+2.26.0
+-----
+* Enabled new rubocop cops:
+  - Lint/EmptyInPattern
+  - Style/StringChars
+  - Style/InPatternThen
+  - Style/MultilineInPatternThen
+  - Style/QuotedSymbols
+* Enabled new rubocop-performance cops:
+  - Performance/MapCompact
+
 2.25.0
 ------
 * Enabled new cops:

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 1.11'
+  spec.add_dependency 'rubocop', '>= 1.16'
   spec.add_dependency 'rubocop-rspec', '>= 2.2.0'
-  spec.add_dependency 'rubocop-performance', '~> 1.10'
+  spec.add_dependency 'rubocop-performance', '>= 1.11'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.25.0'
+  spec.version       = '2.26.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -395,6 +395,9 @@ Lint/SymbolConversion:
 Lint/TripleQuotes:
   Enabled: true
 
+Lint/EmptyInPattern:
+  Enabled: true
+
 Style/ExplicitBlockArgument:
   Enabled: true
 
@@ -447,6 +450,18 @@ Style/SwapValues:
   Enabled: true
 
 Style/RedundantArgument:
+  Enabled: true
+
+Style/StringChars:
+  Enabled: true
+
+Style/InPatternThen:
+  Enabled: true
+
+Style/MultilineInPatternThen:
+  Enabled: true
+
+Style/QuotedSymbols:
   Enabled: true
 
 Layout/BeginEndAlignment:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -269,6 +269,9 @@ Performance/RedundantEqualityComparisonBlock:
 Performance/RedundantSplitRegexpArgument:
   Enabled: true
 
+Performance/MapCompact:
+  Enabled: true
+
 Lint/DuplicateElsifCondition:
   Enabled: true
 


### PR DESCRIPTION
As above. Tested internally, the only one that needs to be fixed is `Performance/MapCompact` but also can be autocorrected.