### PR TITLE
Disable a couple of cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+2.27.0
+-----
+* Disabled a couple of cops:
+  - Style/NegatedIf
+  - Style/IfUnlessModifier
+
 2.26.0
 -----
 * Enabled new rubocop cops:

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.26.0'
+  spec.version       = '2.27.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -142,6 +142,9 @@ Style/HashExcept:
 Style/IfWithBooleanLiteralBranches:
   Enabled: true
 
+Style/IfUnlessModifier:
+  Enabled: false
+
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: space
@@ -438,6 +441,9 @@ Style/DocumentDynamicEvalDefinition:
   Enabled: false
 
 Style/NegatedIfElseCondition:
+  Enabled: false
+
+Style/NegatedIf:
   Enabled: false
 
 Style/ArgumentsForwarding:


### PR DESCRIPTION
We think the following two cops can encourage changes which
detrimentally affect code readability:

  - https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/NegatedIf
  - https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/IfUnlessModifier

Thus, we're disabling them.
