### PR TITLE
Enable support for new cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+2.28.0
+-----
+* Enable support for new cops:
+  - `Layout/LineEndStringConcatenationIndentation`
+  - `Naming/InclusiveLanguage` (disabled by default)
+  - `Lint/AmbiguousRange`
+  - `Style/RedundantSelfAssignmentBranch`
+  - `RSpec/IdenticalEqualityAssertion`
+
 2.27.0
 -----
 * Disabled a couple of cops:

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 1.16'
-  spec.add_dependency 'rubocop-rspec', '>= 2.2.0'
+  spec.add_dependency 'rubocop', '>= 1.19'
+  spec.add_dependency 'rubocop-rspec', '>= 2.4.0'
   spec.add_dependency 'rubocop-performance', '>= 1.11'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.27.0'
+  spec.version       = '2.28.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -30,6 +30,9 @@ Lint/StructNewOverride:
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
+Lint/AmbiguousRange:
+  Enabled: true
+
 Metrics/ClassLength:
   Enabled: false
 
@@ -178,6 +181,9 @@ RSpec/MultipleMemoizedHelpers:
 
 RSpec/StubbedMock:
   Enabled: false
+
+RSpec/IdenticalEqualityAssertion:
+  Enabled: true
 
 # Re-enable this when the following is resolved:
 # https://github.com/rubocop-hq/rubocop/issues/5953
@@ -474,6 +480,9 @@ Style/MultilineInPatternThen:
   Enabled: true
 
 Style/QuotedSymbols:
+  Enabled: true
+
+Style/RedundantSelfAssignmentBranch:
   Enabled: true
 
 Layout/BeginEndAlignment:

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -478,3 +478,6 @@ Layout/BeginEndAlignment:
 
 Layout/SpaceBeforeBrackets:
   Enabled: true
+
+Layout/LineEndStringConcatenationIndentation:
+  Enabled: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -127,6 +127,9 @@ Style/StringLiterals:
 Naming/VariableNumber:
   Enabled: false
 
+Naming/InclusiveLanguage:
+  Enabled: false
+
 Style/YodaCondition:
   Enabled: true
 


### PR DESCRIPTION
Enable support for new cops:
- `Layout/LineEndStringConcatenationIndentation`
- `Naming/InclusiveLanguage` (disabled by default)
- `Lint/AmbiguousRange`
- `Style/RedundantSelfAssignmentBranch`
- `RSpec/IdenticalEqualityAssertion`