### PR TITLE
disable Metrics/MethodLength lint rule

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -46,7 +46,7 @@ Metrics/BlockLength:
   Enabled: false
 
 Metrics/MethodLength:
-  CountComments: false
+  Enabled: false
 
 Metrics/ModuleLength:
   Enabled: false


### PR DESCRIPTION
Line count lint rules do not result in improvements to code cohesion and often times reduce cohesion by breaking up a meaningful function into several smaller, single-use functions. This change disables the rubocop rule that enforces methods to be a maximum of 10 lines of code.

Discussion: https://gocardless.slack.com/archives/C6ZKC4F4L/p1634648427191900

Places where this rule is disabled or modified to increase line count: https://github.com/search?q=org%3Agocardless+Metrics%2FMethodLength+language%3Ayaml&type=code