### PR TITLE
Disable RSpec/FactoryBot/SyntaxMethods

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -185,6 +185,9 @@ RSpec/StubbedMock:
 RSpec/IdenticalEqualityAssertion:
   Enabled: true
 
+RSpec/FactoryBot/SyntaxMethods:
+  Enabled: false
+
 # Re-enable this when the following is resolved:
 # https://github.com/rubocop-hq/rubocop/issues/5953
 Style/AccessModifierDeclarations:


### PR DESCRIPTION
Disabling this cop as it makes it unclear what is actually creating test resources.

Conversation on slack: https://gocardless.slack.com/archives/C6ZKC4F4L/p1641398837205400