### PR TITLE
Prepare for v2.30.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.30.0
+-----
+* Disabled cop:
+  - `RSpec/FactoryBot/SyntaxMethods`
+
 2.29.0
 -----
 * Disabled cop:

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.29.0'
+  spec.version       = '2.30.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'


### PR DESCRIPTION
Release of https://github.com/gocardless/gc_ruboconfig/pull/89