### PR TITLE
Set sensible defaults for 'complexity' metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.31.0
+-----
+* Set sensible defaults for:
+  - `Metrics/AbcSize`
+  - `Metrics/CyclomaticComplexity`
+  - `Metrics/ParameterLists`
+
 2.30.0
 -----
 * Disabled cop:

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.30.0'
+  spec.version       = '2.31.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -36,6 +36,9 @@ Lint/AmbiguousRange:
 Metrics/ClassLength:
   Enabled: false
 
+Metrics/AbcSize:
+  Max: 60
+
 Layout/LineLength:
   Max: 90
 
@@ -53,9 +56,13 @@ Metrics/ModuleLength:
 
 Metrics/ParameterLists:
   CountKeywordArgs: false
+  Max: 10
 
 Metrics/PerceivedComplexity:
   Max: 11
+
+Metrics/CyclomaticComplexity:
+  Max: 10
 
 Style/AsciiComments:
   Enabled: false


### PR DESCRIPTION
The default values are incredibly low and force to write a lot of one liners.
(We already have these settings almost everywhere)