### PR TITLE
Add support for new cops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,34 @@
 Changelog
 =========
 
+2.32.0
+-----
+Adding support for new cops:
+
+* Enabled cops:
+  - `Performance/StringIdentifierArgument` - Only pass symbols to `send`
+  - `Style/MapToHash` - Prefer `to_h {}` over `map {}.to_h`
+  - `Style/NumberedParameters` - Only allow numbered params on single lines
+  - `Style/NumberedParametersLimit` - Cap number of numbered params at 2
+  - `Security/IoMethods` - Disallow direct access to `IO.read` methods
+  - `Gemspec/RequireMFA` - Require MFA annotation on gemspecs
+  - `Lint/AmbiguousOperatorPrecedence` - Wrap arguments in parenthesis to denote operator preference
+  - `Lint/IncompatibleIoSelectWithFiberScheduler` -
+  - `Lint/RequireRelativeSelfPath` - Don't `require_relative` on self
+  - `Lint/UselessRuby2Keywords`
+  - `Naming/BlockForwarding` - Prefer `def foo(&block)` over `def foo(&)`
+  - `RSpec/ExcessiveDocstringSpacing` - Remove extra spaces in rspec `describe/context/it` blocks
+  - `RSpec/SubjectDeclaration` - Ensure `subject` is defined using `subject {}` rather than `let(:subject) {}`
+  - `RSpec/Rails/AvoidSetupHook` - Don't use `setup {}` in tests
+  - `Performance/ConcurrentMonotonicTime` - Use correct monotonic time
+
+* Disabled cops:
+  - `Style/HashSyntax` - Don't permit shorthand hash assignment `foo = 1; { foo: }`
+  - `Style/FileRead` - Allow use of `File.open(path, "r")`
+  - `Style/FileWrite` - Allow use of `File.open(path, "w")`
+  - `Style/OpenStructUse` - Allow use of `OpenStruct`s
+  - `Style/SelectByRegexp` - Allow `select { _1 =~ /regex/ }`
+
 2.31.0
 -----
 * Set sensible defaults for:

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.31.0'
+  spec.version       = '2.32.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = 'rubocop.yml'
-  spec.add_dependency 'rubocop', '>= 1.19'
-  spec.add_dependency 'rubocop-rspec', '>= 2.4.0'
-  spec.add_dependency 'rubocop-performance', '>= 1.11'
+  spec.add_dependency 'rubocop', '>= 1.25'
+  spec.add_dependency 'rubocop-performance', '>= 1.13'
+  spec.add_dependency 'rubocop-rspec', '>= 2.8.0'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -503,3 +503,65 @@ Layout/SpaceBeforeBrackets:
 
 Layout/LineEndStringConcatenationIndentation:
   Enabled: true
+
+Style/HashSyntax:
+  Enabled: false
+
+Style/FileRead:
+  Enabled: false
+
+Style/FileWrite:
+  Enabled: false
+
+Style/MapToHash:
+  Enabled: true
+
+Style/NumberedParameters:
+  Enabled: true
+
+Style/NumberedParametersLimit:
+  Enabled: true
+  Max: 2
+
+Style/OpenStructUse:
+  Enabled: false
+
+Style/SelectByRegexp:
+  Enabled: false
+
+Security/IoMethods:
+  Enabled: true
+
+Gemspec/RequireMFA:
+  Enabled: true
+
+Lint/AmbiguousOperatorPrecedence:
+  Enabled: true
+
+Lint/IncompatibleIoSelectWithFiberScheduler:
+  Enabled: true
+
+Lint/RequireRelativeSelfPath:
+  Enabled: true
+
+Lint/UselessRuby2Keywords:
+  Enabled: true
+
+Naming/BlockForwarding:
+  Enabled: true
+  EnforcedStyle: "explicit"
+
+RSpec/ExcessiveDocstringSpacing:
+  Enabled: true
+
+RSpec/SubjectDeclaration:
+  Enabled: true
+
+RSpec/Rails/AvoidSetupHook:
+  Enabled: true
+
+Performance/ConcurrentMonotonicTime:
+  Enabled: true
+
+Performance/StringIdentifierArgument:
+  Enabled: true


### PR DESCRIPTION
Adding support for new cops:

* Enabled cops:
  - `Performance/StringIdentifierArgument` - Only pass symbols to `send`
  - `Style/MapToHash` - Prefer `to_h {}` over `map {}.to_h`
  - `Style/NumberedParameters` - Only allow numbered params on single lines
  - `Style/NumberedParametersLimit` - Cap number of numbered params at 2
  - `Security/IoMethods` - Disallow direct access to `IO.read` methods
  - `Gemspec/RequireMFA` - Require MFA annotation on gemspecs
  - `Lint/AmbiguousOperatorPrecedence` - Wrap arguments in parenthesis to denote operator preference
  - `Lint/IncompatibleIoSelectWithFiberScheduler` -
  - `Lint/RequireRelativeSelfPath` - Don't `require_relative` on self
  - `Lint/UselessRuby2Keywords`
  - `Naming/BlockForwarding` - Prefer `def foo(&block)` over `def foo(&)`
  - `RSpec/ExcessiveDocstringSpacing` - Remove extra spaces in rspec `describe/context/it` blocks
  - `RSpec/SubjectDeclaration` - Ensure `subject` is defined using `subject {}` rather than `let(:subject) {}`
  - `RSpec/Rails/AvoidSetupHook` - Don't use `setup {}` in tests
  - `Performance/ConcurrentMonotonicTime` - Use correct monotonic time

* Disabled cops:
  - `Style/HashSyntax` - Don't permit shorthand hash assignment `foo = 1; { foo: }`
  - `Style/FileRead` - Allow use of `File.open(path, "r")`
  - `Style/FileWrite` - Allow use of `File.open(path, "w")`
  - `Style/OpenStructUse` - Allow use of `OpenStruct`s
  - `Style/SelectByRegexp` - Allow `select { _1 =~ /regex/ }`
﻿
