### PR TITLE
Include rubocop-rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+2.33.0
+-----
+Adding `rubocop-rails` as part of the default install
+
+* Enabled all `Rails/` cops except:
+  - `Rails/AddColumnIndex` - Allow `index: true` when creating a column
+  - `Rails/ShortI18n` - Use long form `translate` and `localize` instead of `t` and `l`
+
 2.32.0
 -----
 Adding support for new cops:

--- a/README.md
+++ b/README.md
@@ -21,21 +21,3 @@ Next, just inherit from it in your `.rubocop.yml`:
 inherit_gem:
   gc_ruboconfig: rubocop.yml
 ```
-
-## Note for Rails applications
-
-If using `gc_ruboconfig` with a Rails application, you might wish to use `rubocop-rails`
-as well.
-
-In `Gemfile`:
-
-```ruby
-gem 'rubocop-rails'
-```
-
-In `.rubocop.yml`:
-
-```yaml
-require:
-  - rubocop-rails
-```

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '2.32.0'
+  spec.version       = '2.33.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -12,5 +12,6 @@ Gem::Specification.new do |spec|
   spec.files         = 'rubocop.yml'
   spec.add_dependency 'rubocop', '>= 1.25'
   spec.add_dependency 'rubocop-performance', '>= 1.13'
+  spec.add_dependency 'rubocop-rails', '>= 2.13.0'
   spec.add_dependency 'rubocop-rspec', '>= 2.8.0'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-rspec
+  - rubocop-rails
   - rubocop-performance
 
 AllCops:
@@ -564,4 +565,88 @@ Performance/ConcurrentMonotonicTime:
   Enabled: true
 
 Performance/StringIdentifierArgument:
+  Enabled: true
+
+Rails/AddColumnIndex:
+  Enabled: false
+
+Rails/CompactBlank:
+  Enabled: true
+
+Rails/DurationArithmetic:
+  Enabled: true
+
+Rails/EagerEvaluationLogMessage:
+  Enabled: true
+
+Rails/ExpandedDateRange:
+  Enabled: true
+
+Rails/I18nLocaleAssignment:
+  Enabled: true
+
+Rails/RedundantPresenceValidationOnBelongsTo:
+  Enabled: true
+
+Rails/RedundantTravelBack:
+  Enabled: true
+
+Rails/RootJoinChain:
+  Enabled: true
+
+Rails/TimeZoneAssignment:
+  Enabled: true
+
+Rails/UnusedIgnoredColumns:
+  Enabled: true
+
+Rails/ActiveRecordCallbacksOrder:
+  Enabled: true
+
+Rails/AfterCommitOverride:
+  Enabled: true
+
+Rails/AttributeDefaultBlockValue:
+  Enabled: true
+
+Rails/FindById:
+  Enabled: true
+
+Rails/Inquiry:
+  Enabled: true
+
+Rails/MailerName:
+  Enabled: true
+
+Rails/MatchRoute:
+  Enabled: true
+
+Rails/NegateInclude:
+  Enabled: true
+
+Rails/Pluck:
+  Enabled: true
+
+Rails/PluckInWhere:
+  Enabled: true
+
+Rails/RenderInline:
+  Enabled: true
+
+Rails/RenderPlainText:
+  Enabled: true
+
+Rails/ShortI18n:
+  Enabled: false
+
+Rails/SquishedSQLHeredocs:
+  Enabled: true
+
+Rails/WhereEquals:
+  Enabled: true
+
+Rails/WhereExists:
+  Enabled: true
+
+Rails/WhereNot:
   Enabled: true


### PR DESCRIPTION
We currently import these definitions separately for each rails project, leading to inconsistent cop usage per service﻿
