### PR TITLE
Replaces removed cop with suggested alternative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+3.3.0
+-----
+
+Removed `Gemspec/DateAssignment` as it has been removed from rubocop. This is replaced by 
+`Gemspec/DeprecatedAttributeAssignment`
+
 3.2.0
 -----
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '3.2.0'
+  spec.version       = '3.3.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - bin/**/*
     - node_modules/**/*
 
-Gemspec/DateAssignment:
+Gemspec/DeprecatedAttributeAssignment:
   Enabled: true
 
 Lint/RedundantCopEnableDirective:


### PR DESCRIPTION
The `Gemspec/DateAssignment` cop has been removed from rubocop and the suggested
replacemnt is `Gemspec/DeprecatedAttributeAssignment` cop.