### PR TITLE
Fix the rubocop-rspec to v2.12.1 until the v2.3.0 is fixed

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '>= 1.29'
   spec.add_dependency 'rubocop-performance', '>= 1.13'
   spec.add_dependency 'rubocop-rails', '>= 2.14.0'
-  spec.add_dependency 'rubocop-rspec', '>= 2.11.0'
+  spec.add_dependency 'rubocop-rspec', '<= 2.12.1'
 end


### PR DESCRIPTION
Currently a CI step on all new our service PRs is failing as the latest version of rubocop-rspec is missing the obselete.yml file..

While the fix is not released we should fall-back to the working version, v2.12.1