### PR TITLE
Update rubocop-rspec requirement to be >=2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.3.2
+-----
+
+Update rubocop-rspec requirement to be >=2.13.1
+
 3.3.1
 -----
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '3.3.1'
+  spec.version       = '3.3.2'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -13,5 +13,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '>= 1.29'
   spec.add_dependency 'rubocop-performance', '>= 1.13'
   spec.add_dependency 'rubocop-rails', '>= 2.14.0'
-  spec.add_dependency 'rubocop-rspec', '<= 2.12.1'
+  spec.add_dependency 'rubocop-rspec', '>= 2.13.1'
 end


### PR DESCRIPTION
Update rubocop-rspec requirement to be >=2.13.1

The [release](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.13.1) fixed the issue in v2.13.0, so okay to bump to latest version