### PR TITLE
Setting RSpec/Rails/HttpStatus style to numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.5.0
+-----
+
+Set [RSpec/Rails/HttpStatus](https://docs.rubocop.org/rubocop-rspec/cops_rspec_rails.html#rspecrailshttpstatus)'s enforced style to numeric
+
 3.4.0
 -----
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '3.4.0'
+  spec.version       = '3.5.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rails.yml
+++ b/rails.yml
@@ -141,3 +141,12 @@ Rails/TopLevelHashWithIndifferentAccess: # new in 2.16
 
 Rails/WhereMissing: # new in 2.16
   Enabled: true
+
+RSpec/Rails/HaveHttpStatus:  # new in 2.12
+  Enabled: true
+
+RSpec/Rails/AvoidSetupHook:
+  Enabled: true
+
+RSpec/Rails/HttpStatus:
+  EnforcedStyle: numeric

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -557,9 +557,6 @@ RSpec/ExcessiveDocstringSpacing:
 RSpec/SubjectDeclaration:
   Enabled: true
 
-RSpec/Rails/AvoidSetupHook:
-  Enabled: true
-
 Performance/ConcurrentMonotonicTime:
   Enabled: true
 
@@ -647,8 +644,4 @@ RSpec/Capybara/SpecificFinders:
 
  # new in 2.12
 RSpec/Capybara/SpecificMatcher:
-  Enabled: true
-
- # new in 2.12
-RSpec/Rails/HaveHttpStatus:
   Enabled: true


### PR DESCRIPTION
Rather than having to remember the symbols for each http status we can
just use the numeric values as usual
