### PR TITLE
Add new cops v3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+3.6.0
+-----
+
+Add cops from:
+
+- rubocop 1.37.1
+- rubocop-rspec 2.14.2 
+- rubocop-rails 2.17.2 
+
 3.5.0
 -----
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '3.5.0'
+  spec.version       = '3.6.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = ['rubocop.yml', 'rails.yml']
-  spec.add_dependency 'rubocop', '>= 1.36'
-  spec.add_dependency 'rubocop-performance', '>= 1.13'
-  spec.add_dependency 'rubocop-rails', '>= 2.16.1'
-  spec.add_dependency 'rubocop-rspec', '>= 2.13.2'
+  spec.add_dependency 'rubocop', '>= 1.37.1'
+  spec.add_dependency 'rubocop-performance', '>= 1.15'
+  spec.add_dependency 'rubocop-rails', '>= 2.17.2'
+  spec.add_dependency 'rubocop-rspec', '>= 2.14.2'
 end

--- a/rails.yml
+++ b/rails.yml
@@ -142,7 +142,7 @@ Rails/TopLevelHashWithIndifferentAccess: # new in 2.16
 Rails/WhereMissing: # new in 2.16
   Enabled: true
 
-RSpec/Rails/HaveHttpStatus:  # new in 2.12
+RSpec/Rails/HaveHttpStatus: # new in 2.12
   Enabled: true
 
 RSpec/Rails/AvoidSetupHook:
@@ -150,3 +150,16 @@ RSpec/Rails/AvoidSetupHook:
 
 RSpec/Rails/HttpStatus:
   EnforcedStyle: numeric
+
+RSpec/Rails/InferredSpecType: # new in 2.14
+  Enabled: false
+
+Rails/ActionOrder: # new in 2.17
+  Enabled: false
+
+Rails/IgnoredColumnsAssignment: # new in 2.17
+  Enabled: true
+
+# Only relevant for Rails < 6.1
+Rails/WhereNotWithMultipleConditions: # new in 2.17
+  Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -638,10 +638,32 @@ RSpec/ClassCheck:
 RSpec/NoExpectationExample:
   Enabled: false
 
- # new in 2.13
+# new in 2.13
 RSpec/Capybara/SpecificFinders:
   Enabled: true
 
- # new in 2.12
+# new in 2.12
 RSpec/Capybara/SpecificMatcher:
   Enabled: true
+
+Lint/DuplicateMagicComment: # new in 1.37
+  Enabled: true
+
+Style/OperatorMethodCall: # new in 1.37
+  Enabled: true
+
+Style/RedundantStringEscape: # new in 1.37
+  Enabled: true
+
+RSpec/SortMetadata: # new in 2.14
+  Enabled: true
+
+RSpec/Capybara/NegationMatcher: # new in 2.14
+  Enabled: true
+
+RSpec/Capybara/SpecificActions: # new in 2.14
+  Enabled: false
+
+# Seems to be buggy, causes an infinite loop for `subjects` named `create`
+RSpec/FactoryBot/ConsistentParenthesesStyle: # new in 2.14
+  Enabled: false


### PR DESCRIPTION
```yaml
RSpec/Rails/InferredSpecType: # new in 2.14
  Enabled: false

Rails/ActionOrder: # new in 2.17
  Enabled: false

Rails/IgnoredColumnsAssignment: # new in 2.17
  Enabled: true

# Only relevant for Rails < 6.1
Rails/WhereNotWithMultipleConditions: # new in 2.17
  Enabled: false

Lint/DuplicateMagicComment: # new in 1.37
  Enabled: true

Style/OperatorMethodCall: # new in 1.37
  Enabled: true

Style/RedundantStringEscape: # new in 1.37
  Enabled: true

RSpec/SortMetadata: # new in 2.14
  Enabled: true

RSpec/Capybara/NegationMatcher: # new in 2.14
  Enabled: true

RSpec/Capybara/SpecificActions: # new in 2.14
  Enabled: false

# Seems to be buggy, causes an infinite loop for `subjects` named `create`
RSpec/FactoryBot/ConsistentParenthesesStyle: # new in 2.14
  Enabled: false
```