### PR TITLE
Fix warnings on the `RSpec/Capybara` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+3.6.1
+-----
+
+Fix `RSpec/Capybara` namespace warnings
+
 3.6.0
 -----
 

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '3.6.0'
+  spec.version       = '3.6.1'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -639,11 +639,11 @@ RSpec/NoExpectationExample:
   Enabled: false
 
 # new in 2.13
-RSpec/Capybara/SpecificFinders:
+Capybara/SpecificFinders:
   Enabled: true
 
 # new in 2.12
-RSpec/Capybara/SpecificMatcher:
+Capybara/SpecificMatcher:
   Enabled: true
 
 Lint/DuplicateMagicComment: # new in 1.37
@@ -658,10 +658,10 @@ Style/RedundantStringEscape: # new in 1.37
 RSpec/SortMetadata: # new in 2.14
   Enabled: true
 
-RSpec/Capybara/NegationMatcher: # new in 2.14
+Capybara/NegationMatcher: # new in 2.14
   Enabled: true
 
-RSpec/Capybara/SpecificActions: # new in 2.14
+Capybara/SpecificActions: # new in 2.14
   Enabled: false
 
 # Seems to be buggy, causes an infinite loop for `subjects` named `create`


### PR DESCRIPTION
This addresses the following errors when running rubocop in payments-service:

```
~gems/gc_ruboconfig-3.6.0/rubocop.yml: RSpec/Capybara/SpecificFinders has the wrong namespace - should be Capybara
~gems/gc_ruboconfig-3.6.0/rubocop.yml: RSpec/Capybara/SpecificMatcher has the wrong namespace - should be Capybara
~gems/gc_ruboconfig-3.6.0/rubocop.yml: RSpec/Capybara/NegationMatcher has the wrong namespace - should be Capybara
~gems/gc_ruboconfig-3.6.0/rubocop.yml: RSpec/Capybara/SpecificActions has the wrong namespace - should be Capybara
```
