### PR TITLE
Fix warnings on the `RSpec/FactoryBot` namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Changelog
 * Drop support for Ruby 2.6
 * Bump minimum rubocop version to 1.50.0
 * Add Ruby 3.2 to test version matrix
+* Fix `RSpec/FactoryBot` namespace warnings for rubocop-rspec >= 2.22.0
+  * FactoryBot cops have now been moved out into a new `rubocop-factory_bot` gem
+* Bump rubocop-rspec minimum version to 2.22.0
 
 3.6.2
 -----

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop', '>= 1.50.0'
   spec.add_dependency 'rubocop-performance', '>= 1.15'
   spec.add_dependency 'rubocop-rails', '>= 2.17.2'
-  spec.add_dependency 'rubocop-rspec', '>= 2.14.2'
+  spec.add_dependency 'rubocop-rspec', '>= 2.22.0'
 end

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -192,7 +192,7 @@ RSpec/StubbedMock:
 RSpec/IdenticalEqualityAssertion:
   Enabled: true
 
-RSpec/FactoryBot/SyntaxMethods:
+FactoryBot/SyntaxMethods:
   Enabled: false
 
 # Re-enable this when the following is resolved:
@@ -665,5 +665,5 @@ Capybara/SpecificActions: # new in 2.14
   Enabled: false
 
 # Seems to be buggy, causes an infinite loop for `subjects` named `create`
-RSpec/FactoryBot/ConsistentParenthesesStyle: # new in 2.14
+FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: false


### PR DESCRIPTION
This fixes the following errors when running rubocop >= 2.22.0 as FactoryBot cops have been moved into the `rubocop-factory_bot` gem

```
.rubocop.yml: RSpec/FactoryBot/SyntaxMethods has the wrong namespace - should be FactoryBot
.rubocop.yml: RSpec/FactoryBot/ConsistentParenthesesStyle has the wrong namespace - should be FactoryBot
```