### PR TITLE
Drop support for Ruby 2.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
   validate:
     strategy:
       matrix:
-        ruby-version: [2.6, 2.7, 3.0, 3.1]
+        ruby-version: [2.7, 3.0, 3.1, 3.2]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+4.0.0
+-----
+
+* Drop support for Ruby 2.6
+* Bump minimum rubocop version to 1.50.0
+* Add Ruby 3.2 to test version matrix
+
 3.6.2
 -----
 
@@ -18,8 +25,8 @@ Fix `RSpec/Capybara` namespace warnings
 Add cops from:
 
 - rubocop 1.37.1
-- rubocop-rspec 2.14.2 
-- rubocop-rails 2.17.2 
+- rubocop-rspec 2.14.2
+- rubocop-rails 2.17.2
 
 3.5.0
 -----

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '3.6.2'
+  spec.version       = '4.0.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   spec.files         = ['rubocop.yml', 'rails.yml']
-  spec.add_dependency 'rubocop', '>= 1.37.1'
+  spec.add_dependency 'rubocop', '>= 1.50.0'
   spec.add_dependency 'rubocop-performance', '>= 1.15'
   spec.add_dependency 'rubocop-rails', '>= 2.17.2'
   spec.add_dependency 'rubocop-rspec', '>= 2.14.2'


### PR DESCRIPTION
We haven't supported Ruby 2.6 for a while now at GC so there's no reason to keep supporting it in this gem, and it's preventing dependency updates

We don't support Ruby 2.7 either, but current RSpec still does, so I've left it in for now