### PR TITLE
Increase linelength limit to 120

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '4.0.0'
+  spec.version       = '4.0.1'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -40,7 +40,7 @@ Metrics/AbcSize:
   Max: 60
 
 Layout/LineLength:
-  Max: 90
+  Max: 100
 
 Layout/EmptyLinesAroundAttributeAccessor:
   Enabled: true


### PR DESCRIPTION
We've found that 90 chars is quite limiting and workarounds tend to be less readable. So increase limit to 100