### PR TITLE
Disable Style/ReturnNilInPredicateMethodDefinition

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -123,6 +123,9 @@ Style/NumericPredicate:
 Style/NumericLiterals:
   MinDigits: 11
 
+Style/ReturnNilInPredicateMethodDefinition:
+  Enabled: false
+
 Style/SignalException:
   EnforcedStyle: "only_raise"
 


### PR DESCRIPTION
Some of our legacy code relies on returning nil from predicate methods to indicate things such as missing values, so this would be changing behaviour

https://docs.rubocop.org/rubocop/cops_style.html#stylereturnnilinpredicatemethoddefinition