### PR TITLE
Disable rule as it's misbehaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+4.4.1
+-----
+* Disable `HashEachMethods` style for [Style/HashEachMethods](https://docs.rubocop.org/rubocop/cops_style.html#stylehasheachmethods)
+
+
 4.4.0
 -----
 * Enforce `always` style for [Style/AndOr](https://docs.rubocop.org/rubocop/cops_style.html#styleandor)

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '4.4.0'
+  spec.version       = '4.4.1'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -209,7 +209,7 @@ Style/ModuleFunction:
   Enabled: false
 
 Style/HashEachMethods:
-  Enabled: true
+  Enabled: false
 
 Style/HashTransformKeys:
   Enabled: true


### PR DESCRIPTION
```
[1] (main)> [["AA", "a"]].each { |key, value| puts key.to_s }
AA
=> [["AA", "a"]]
[2] (main)> [["AA", "a"]].each_key { |key, value| puts key.to_s }
NoMethodError: undefined method `each_key' for [["AA", "a"]]:Array
from (pry):2:in `__pry__'
[3] (main)> [["AA", "a"]].to_h.each_key { |key, value| puts key.to_s }
AA
=> {"AA"=>"a"}
```