### PR TITLE
Disable RSpec/ExampleWording

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -675,3 +675,7 @@ FactoryBot/ConsistentParenthesesStyle: # new in 2.14
 Style/AndOr:
   Enabled: true
   EnforcedStyle: always
+
+# Autocorrect is a little simplified and can lead to confusion
+RSpec/ExampleWording:
+  Enabled: false


### PR DESCRIPTION
Autocorrecting this can lead to confusing results, an example of this going wrong is at # https://github.com/gocardless/abacus/pull/3268#pullrequestreview-1809073293

So we decided to disable it instead since it is quite low value to have.