### PR TITLE
Ensure rubocop can parse rules

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '4.4.1'
+  spec.version       = '4.4.2'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rails.yml
+++ b/rails.yml
@@ -148,7 +148,7 @@ RSpec/Rails/HaveHttpStatus: # new in 2.12
 RSpec/Rails/AvoidSetupHook:
   Enabled: true
 
-RSpec/Rails/HttpStatus:
+RSpecRails/HttpStatus:
   EnforcedStyle: numeric
 
 RSpec/Rails/InferredSpecType: # new in 2.14

--- a/rails.yml
+++ b/rails.yml
@@ -142,16 +142,16 @@ Rails/TopLevelHashWithIndifferentAccess: # new in 2.16
 Rails/WhereMissing: # new in 2.16
   Enabled: true
 
-RSpec/Rails/HaveHttpStatus: # new in 2.12
+RSpecRails/HaveHttpStatus: # new in 2.12
   Enabled: true
 
-RSpec/Rails/AvoidSetupHook:
+RSpecRails/AvoidSetupHook:
   Enabled: true
 
 RSpecRails/HttpStatus:
   EnforcedStyle: numeric
 
-RSpec/Rails/InferredSpecType: # new in 2.14
+RSpecRails/InferredSpecType: # new in 2.14
   Enabled: false
 
 Rails/ActionOrder: # new in 2.17


### PR DESCRIPTION
```
Error: Ambiguous cop name `RSpec/Rails/HttpStatus` used in
/Users/krobayna/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/gc_ruboconfig-4.4.1/rails.yml
needs department qualifier. Did you mean Rails/HttpStatus or
RSpecRails/HttpStatus?
```

The rule was updated
https://docs.rubocop.org/rubocop-rspec_rails/cops_rspecrails.html#rspecrailshttpstatus