### PR TITLE
Update for rubocop-rspec 3.0.0 >=

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+4.6.0
+-----
+* Adjustment for supporting rubocop-rspec 3.0.0 >=
+
 4.5.0
 -----
 * Drop support for Ruby 2.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
 Changelog
 =========
 
-4.6.0
+5.0.0
 -----
 * Adjustment for supporting rubocop-rspec 3.0.0 >=
+* Bringing out out capybara cop in its own file.
+  * This require 'rubocop-capybara' gem to be added to support the cop rules.
+
+Example:
+```yaml
+inherit_gem:
+  gc_ruboconfig:
+    - rubocop.yml
+    - rails.yml
+    - capybara.yml
+```
 
 4.5.0
 -----

--- a/capybara.yml
+++ b/capybara.yml
@@ -1,0 +1,16 @@
+require:
+  - rubocop-capybara
+
+# new in 2.13
+Capybara/SpecificFinders:
+  Enabled: true
+
+# new in 2.12
+Capybara/SpecificMatcher:
+  Enabled: true
+  
+Capybara/NegationMatcher: # new in 2.14
+  Enabled: true
+
+Capybara/SpecificActions: # new in 2.14
+  Enabled: false

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,16 +2,15 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '4.6.0'
+  spec.version       = '5.0.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'
   spec.email         = %w[developers@gocardless.com]
   spec.license       = 'MIT'
 
-  spec.files         = ['rubocop.yml', 'rails.yml']
+  spec.files         = ['rubocop.yml', 'rails.yml', 'capybara.yml']
   spec.add_dependency 'rubocop', '>= 1.63'
-  spec.add_dependency 'rubocop-capybara', '>= 2.21.0'
   spec.add_dependency 'rubocop-factory_bot', '>= 2.26.1'
   spec.add_dependency 'rubocop-performance', '>= 1.21'
   spec.add_dependency 'rubocop-rails', '>= 2.25.0'

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '4.5.0'
+  spec.version       = '4.6.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -11,7 +11,10 @@ Gem::Specification.new do |spec|
 
   spec.files         = ['rubocop.yml', 'rails.yml']
   spec.add_dependency 'rubocop', '>= 1.63'
+  spec.add_dependency 'rubocop-capybara', '>= 2.21.0'
+  spec.add_dependency 'rubocop-factory_bot', '>= 2.26.1'
   spec.add_dependency 'rubocop-performance', '>= 1.21'
   spec.add_dependency 'rubocop-rails', '>= 2.25.0'
-  spec.add_dependency 'rubocop-rspec', '>= 2.29.2'
+  spec.add_dependency 'rubocop-rspec', '>= 3.0.1'
+  spec.add_dependency 'rubocop-rspec_rails', '>= 2.30.0'
 end

--- a/rails.yml
+++ b/rails.yml
@@ -1,5 +1,6 @@
 require:
   - rubocop-rails
+  - rubocop-rspec_rails
 
 Rails/AddColumnIndex:
   Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,10 @@
 require:
   - rubocop-rspec
   - rubocop-performance
+  - rubocop-factory_bot
+  - rubocop-capybara
+  - rubocop-rails
+  - rubocop-rspec_rails
 
 AllCops:
   DisplayCopNames: true

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -2,9 +2,6 @@ require:
   - rubocop-rspec
   - rubocop-performance
   - rubocop-factory_bot
-  - rubocop-capybara
-  - rubocop-rails
-  - rubocop-rspec_rails
 
 AllCops:
   DisplayCopNames: true
@@ -646,14 +643,6 @@ RSpec/ClassCheck:
 RSpec/NoExpectationExample:
   Enabled: false
 
-# new in 2.13
-Capybara/SpecificFinders:
-  Enabled: true
-
-# new in 2.12
-Capybara/SpecificMatcher:
-  Enabled: true
-
 Lint/DuplicateMagicComment: # new in 1.37
   Enabled: true
 
@@ -665,12 +654,6 @@ Style/RedundantStringEscape: # new in 1.37
 
 RSpec/SortMetadata: # new in 2.14
   Enabled: true
-
-Capybara/NegationMatcher: # new in 2.14
-  Enabled: true
-
-Capybara/SpecificActions: # new in 2.14
-  Enabled: false
 
 # Seems to be buggy, causes an infinite loop for `subjects` named `create`
 FactoryBot/ConsistentParenthesesStyle: # new in 2.14


### PR DESCRIPTION
Came across error in different gem when rubocop-rspec version was auto bumped to 3.0.1. 

So seems from 3.0.0 >= the cops are separated in different repos, so they need to added as separate gems and you need require in yml file. 
Described changes: https://docs.rubocop.org/rubocop-rspec/upgrade_to_version_3.html