### PR TITLE
Change how rules are referenced

### DIFF
--- a/capybara.yml
+++ b/capybara.yml
@@ -2,15 +2,14 @@ require:
   - rubocop-capybara
 
 # new in 2.13
-Capybara/SpecificFinders:
+RSpec/Capybara/SpecificFinders:
   Enabled: true
 
-# new in 2.12
-Capybara/SpecificMatcher:
-  Enabled: true
-  
-Capybara/NegationMatcher: # new in 2.14
+RSpec/Capybara/SpecificMatcher: # new in 2.12
   Enabled: true
 
-Capybara/SpecificActions: # new in 2.14
+RSpec/Capybara/NegationMatcher: # new in 2.14
+  Enabled: true
+
+RSpec/Capybara/SpecificActions: # new in 2.14
   Enabled: false

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '5.0.0'
+  spec.version       = '5.0.1'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -656,7 +656,7 @@ RSpec/SortMetadata: # new in 2.14
   Enabled: true
 
 # Seems to be buggy, causes an infinite loop for `subjects` named `create`
-FactoryBot/ConsistentParenthesesStyle: # new in 2.14
+RSpec/FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: false
 
 Style/AndOr:


### PR DESCRIPTION
These ones should be prefixed by RSpec as otherwise we get an error

![image](https://github.com/gocardless/gc_ruboconfig/assets/5471469/72ead511-01e3-4b39-a5e9-6179920afdde)
