### PR TITLE
Revert "Change how rules are referenced"

### DIFF
--- a/capybara.yml
+++ b/capybara.yml
@@ -2,14 +2,15 @@ require:
   - rubocop-capybara
 
 # new in 2.13
-RSpec/Capybara/SpecificFinders:
+Capybara/SpecificFinders:
   Enabled: true
 
-RSpec/Capybara/SpecificMatcher: # new in 2.12
+# new in 2.12
+Capybara/SpecificMatcher:
+  Enabled: true
+  
+Capybara/NegationMatcher: # new in 2.14
   Enabled: true
 
-RSpec/Capybara/NegationMatcher: # new in 2.14
-  Enabled: true
-
-RSpec/Capybara/SpecificActions: # new in 2.14
+Capybara/SpecificActions: # new in 2.14
   Enabled: false

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '5.0.1'
+  spec.version       = '5.0.0'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -656,7 +656,7 @@ RSpec/SortMetadata: # new in 2.14
   Enabled: true
 
 # Seems to be buggy, causes an infinite loop for `subjects` named `create`
-RSpec/FactoryBot/ConsistentParenthesesStyle: # new in 2.14
+FactoryBot/ConsistentParenthesesStyle: # new in 2.14
   Enabled: false
 
 Style/AndOr:


### PR DESCRIPTION
Reverts gocardless/gc_ruboconfig#124

This change fixes an issue caused by a downstream service not having the new `rubocop-factory_bot` gem in its dependencies, but does it in the wrong way. These old namespaces were deprecated long ago and the correct fix is to add a dependency on the new gem, either here or in services that depend on this gem

See https://docs.rubocop.org/rubocop-rspec/upgrade_to_version_3.html