### PR TITLE
Update minimum required versions of pluginified dependencies

### DIFF
--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |spec|
   spec.files         = ['rubocop.yml', 'rails.yml', 'capybara.yml']
   spec.add_dependency 'rubocop', '>= 1.63'
   spec.add_dependency 'rubocop-factory_bot', '>= 2.26.1'
-  spec.add_dependency 'rubocop-performance', '>= 1.21'
-  spec.add_dependency 'rubocop-rails', '>= 2.25.0'
-  spec.add_dependency 'rubocop-rspec', '>= 3.0.1'
+  spec.add_dependency 'rubocop-performance', '>= 1.24'
+  spec.add_dependency 'rubocop-rails', '>= 2.30.0'
+  spec.add_dependency 'rubocop-rspec', '>= 3.5.0'
   spec.add_dependency 'rubocop-rspec_rails', '>= 2.30.0'
 end

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = 'gc_ruboconfig'
-  spec.version       = '5.0.3'
+  spec.version       = '5.0.4'
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w[GoCardless]
   spec.homepage      = 'https://github.com/gocardless/ruboconfig'


### PR DESCRIPTION
Followup to #127

Update the minimum required versions of dependencies to the versions in which they were converted to be plugins, so that the updated config to use them as plugins doesn't break downstream consumers with differing version constraints

See:
* https://github.com/rubocop/rubocop-rspec/releases/tag/v3.5.0
* https://github.com/rubocop/rubocop-rails/releases/tag/v2.30.0
* https://github.com/rubocop/rubocop-performance/releases/tag/v1.24.0